### PR TITLE
gitignore `inputs` and `outputs` directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 inputs/
 outputs/
+data/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+inputs/
+outputs/


### PR DESCRIPTION
These are the default directories expected when running `main.R` interactively using RStudio. 

Alternative I/O paths can be customized using the `.env` file when triggering a containerized run using docker.

See equivalent behaviour in https://github.com/RMI-PACTA/workflow.scenario.preparation/blob/26811fa194d88279e534c79f77328f4a217f5524/.gitignore#L54-L56