### PR TITLE
add all scenarios to output of `prep_emissions_trajectory()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: workflow.pacta.dashboard
 Title: Run PACTA dashboard JSON generation
-Version: 0.0.0.9002
+Version: 0.0.0.9003
 Authors@R:
     c(person(given = "Alex",
              family = "Axthelm",

--- a/R/prep_emissions_trajectory.R
+++ b/R/prep_emissions_trajectory.R
@@ -1,10 +1,7 @@
 prep_emissions_trajectory <-
   function(equity_results_portfolio,
            bonds_results_portfolio,
-           investor_name,
            portfolio_name,
-           select_scenario_other,
-           select_scenario,
            pacta_sectors,
            year_span,
            start_year
@@ -23,15 +20,19 @@ prep_emissions_trajectory <-
     list(`Listed Equity` = equity_results_portfolio,
            `Corporate Bonds` = bonds_results_portfolio) %>%
       bind_rows(.id = "asset_class") %>%
-      filter(.data$investor_name == .env$investor_name,
-             .data$portfolio_name == .env$portfolio_name) %>%
-      filter_scenarios_per_sector(
-        select_scenario_other,
-        select_scenario
-      ) %>%
+      filter(.data$portfolio_name == .env$portfolio_name) %>%
       filter(.data$scenario_geography == "Global") %>%
-      select("asset_class", "allocation", "equity_market", sector = "ald_sector", "year",
-             plan = "plan_sec_emissions_factor", scen = "scen_sec_emissions_factor", "scenario") %>%
+      select(
+        "asset_class",
+        "allocation",
+        "equity_market",
+        sector = "ald_sector",
+        "year",
+        plan = "plan_sec_emissions_factor",
+        scen = "scen_sec_emissions_factor",
+        "scenario",
+        "scenario_source"
+      ) %>%
       distinct() %>%
       filter(!is.nan(.data$plan)) %>%
       pivot_longer(c("plan", "scen"), names_to = "plan") %>%

--- a/R/prepare_pacta_dashboard_data.R
+++ b/R/prepare_pacta_dashboard_data.R
@@ -280,10 +280,7 @@ prep_trajectory_alignment(
 prep_emissions_trajectory(
   equity_results_portfolio = equity_results_portfolio,
   bonds_results_portfolio = bonds_results_portfolio,
-  investor_name = investor_name,
   portfolio_name = portfolio_name,
-  select_scenario_other = select_scenario_other,
-  select_scenario = select_scenario,
   pacta_sectors = pacta_sectors,
   year_span = year_span,
   start_year = start_year


### PR DESCRIPTION
- supersedes #26 (due to significant changes in #30)
- depends on a paired PR in https://github.com/RMI-PACTA/pacta-dashboard-svelte being complete (https://github.com/RMI-PACTA/pacta-dashboard-svelte/pull/125)
- works towards https://github.com/RMI-PACTA/pacta-dashboard-svelte/issues/41
