### PR TITLE
build(docker): #43 Allow multi-architecture builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 FROM docker.io/rocker/r-ver:4.3.1 AS base
 
-RUN CRAN_LIKE_URL="https://packagemanager.posit.co/cran/__linux__/jammy/2024-04-05"; \
-    echo "options(repos = c(CRAN = '$CRAN_LIKE_URL'))" \
-    > "${R_HOME}/etc/Rprofile.site"
-
 # install system dependencies
 RUN apt-get update \
     && DEBIAN_FRONTEND="noninteractive" \
@@ -12,8 +8,40 @@ RUN apt-get update \
     && chmod -R a+rwX /root \
     && rm -rf /var/lib/apt/lists/*
 
+# set frozen CRAN repo and RProfile.site
+# This block makes use of the builtin ARG $TARGETPLATFORM (See:
+# https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
+# ) to pick the correct CRAN-like repo, which will let us target binaries fo
+# supported platforms
+ARG TARGETPLATFORM
+RUN PACKAGE_PIN_DATE="2024-03-05" && \
+  echo "TARGETPLATFORM: $TARGETPLATFORM" && \
+  if [ "$TARGETPLATFORM" = "linux/amd64" ] && grep -q -e "Jammy Jellyfish" "/etc/os-release" ; then \
+    CRAN_LIKE_URL="https://packagemanager.posit.co/cran/__linux__/jammy/$PACKAGE_PIN_DATE"; \
+  else \
+    CRAN_LIKE_URL="https://packagemanager.posit.co/cran/$PACKAGE_PIN_DATE"; \
+  fi && \
+  echo "CRAN_LIKE_URL: $CRAN_LIKE_URL" && \
+  printf "options(\n \
+    repos = c(CRAN = '%s'),\n \
+    pak.no_extra_messages = TRUE,\n \
+    pkg.sysreqs = FALSE,\n \
+    pkg.sysreqs_db_update = FALSE,\n \
+    pkg.sysreqs_update = FALSE\n \
+  )\n" \
+  "$CRAN_LIKE_URL" \
+  > "${R_HOME}/etc/Rprofile.site"
+
 # install pak
-RUN Rscript -e "install.packages('pak', repos = 'https://r-lib.github.io/p/pak/stable/')"
+RUN Rscript -e "install.packages( \
+      'pak', \
+      repos = sprintf( \
+        'https://r-lib.github.io/p/pak/stable/%s/%s/%s', \
+        .Platform[['pkgType']], \
+        R.Version()[['os']], \
+        R.Version()[['arch']] \
+      ) \
+    )"
 
 # copy in DESCRIPTION from this repo
 COPY DESCRIPTION /workflow.pacta.dashboard/DESCRIPTION


### PR DESCRIPTION
Update `Dockerfile` to allow multiarch builds, by targeting non `x86_64` archs for `pak` and other R package installation.

Closes: #43