### PR TITLE
Feat/27 archive export

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: workflow.pacta.dashboard
 Title: Run PACTA dashboard JSON generation
-Version: 0.0.0.9005
+Version: 0.0.0.9006
 Authors@R:
     c(person(given = "Alex",
              family = "Axthelm",

--- a/R/prepare_pacta_dashboard_data.R
+++ b/R/prepare_pacta_dashboard_data.R
@@ -343,7 +343,7 @@ prep_key_bars_portfolio(
 
 # put JSON and CSV outputs into a zip archive ----------------------------------
 
-# zip_outputs(output_dir)
+zip_outputs(output_dir)
 
 }
 
@@ -362,15 +362,19 @@ zip_outputs <- function(output_dir) {
     
     csv_filename <- sub("[.]json$", ".csv", json_filename)
     
-    jsonlite::read_json(
+    df <- jsonlite::read_json(
       path = file.path(output_dir, json_filename),
       simplifyVector = TRUE
-    ) %>% 
+    ) 
+
+    if (inherits(df, "data.frame")) {
       readr::write_csv(
+        x = df,
         file = file.path(zip_temp, csv_filename),
         na = "",
         eol = "\n"
       )
+    }
   }
   
   utils::zip(


### PR DESCRIPTION
re-enable zip output and csv conversion.

Note: if a JSON file is does not read as a data.frame (empty array, `[]`), then this will not emit a corresponding csv file, but will add the empty JSON to the archive (for later diagnostic purposes).

Closes: https://github.com/RMI-PACTA/workflow.pacta.dashboard/issues/27

Tested with empty JSON files on my machine