### PR TITLE
Enable R check for sysdeps

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,8 +18,6 @@ jobs:
   docker:
     name: Docker actions
     uses: RMI-PACTA/actions/.github/workflows/docker.yml@main
-    with:
-      do-check-r-sysdeps: false
 
   test:
     name: Test

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
       git=1:2.34.* \
       libcurl4-openssl-dev=7.81.* \
       libgit2-dev=1.1.* \
-      libicu-dev=71.1.* \
+      libicu-dev=70.* \
       libnode-dev=12.22.* \
       libssl-dev=3.0.* \
     && chmod -R a+rwX /root \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@ RUN apt-get update \
     && DEBIAN_FRONTEND="noninteractive" \
     apt-get install -y --no-install-recommends \
       git=1:2.34.* \
+      libcurl4-openssl-dev=7.81.* \
+      libgit2-dev=1.1.* \
+      libicu-dev=71.1.* \
+      libnode-dev=12.22.* \
+      libssl-dev=3.0.* \
     && chmod -R a+rwX /root \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Address failing [build on`main`](https://github.com/RMI-PACTA/workflow.pacta.dashboard/actions/runs/12318754670/job/34384197980#step:11:574) by including required system dependencies

- Add sysdeps
- enable workflow to check for R sysdeps in Docker image