### PR TITLE
Allow missing EQ or CB results

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,6 +32,8 @@ jobs:
           - default_2023Q4
           - full_params_2022Q4
           - full_params_2023Q4
+          - only-cb_2023Q4
+          - only-eq_2023Q4
     with:
       full-image-name: ${{ needs.docker.outputs.full-image-name }}
       config-name: ${{ matrix.config-name }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: workflow.pacta.dashboard
 Title: Run PACTA dashboard JSON generation
-Version: 0.0.0.9009
+Version: 0.0.0.9010
 Authors@R:
     c(person(given = "Alex",
              family = "Axthelm",

--- a/R/prepare_pacta_dashboard_data.R
+++ b/R/prepare_pacta_dashboard_data.R
@@ -56,15 +56,29 @@ audit_file <- readRDS(file.path(analysis_output_dir, "audit_file.rds"))
 log_trace("Loading emissions.rds")
 emissions <- readRDS(file.path(analysis_output_dir, "emissions.rds"))
 
-log_trace("Loading Equity_results_portfolio.rds")
-equity_results_portfolio <- readRDS(file.path(analysis_output_dir, "Equity_results_portfolio.rds"))
-log_trace("Loading Bonds_results_portfolio.rds")
-bonds_results_portfolio <- readRDS(file.path(analysis_output_dir, "Bonds_results_portfolio.rds"))
-log_trace("Loading Equity_results_company.rds")
-equity_results_company <- readRDS(file.path(analysis_output_dir, "Equity_results_company.rds"))
-log_trace("Loading Bonds_results_company.rds")
-bonds_results_company <- readRDS(file.path(analysis_output_dir, "Bonds_results_company.rds"))
+equity_results_portfolio_path <- file.path(analysis_output_dir, "Equity_results_portfolio.rds")
+if (file.exists(equity_results_portfolio_path)) {
+  log_trace("Loading Equity_results_portfolio.rds")
+  equity_results_portfolio <- readRDS(equity_results_portfolio_path)
+  log_trace("Loading Equity_results_company.rds")
+  equity_results_company <- readRDS(file.path(analysis_output_dir, "Equity_results_company.rds"))
+} else {
+  log_warn("Equity_results_portfolio.rds not found. Creating empty data frame.")
+  equity_results_portfolio <- pacta.portfolio.utils::empty_portfolio_results()
+  equity_results_company <- pacta.portfolio.utils::empty_company_results()
+}
 
+bonds_results_portfolio_path <- file.path(analysis_output_dir, "Bonds_results_portfolio.rds")
+if (file.exists(bonds_results_portfolio_path)) {
+  log_trace("Loading Bonds_results_portfolio.rds")
+  bonds_results_portfolio <- readRDS(bonds_results_portfolio_path)
+  log_trace("Loading Bonds_results_company.rds")
+  bonds_results_company <- readRDS(file.path(analysis_output_dir, "Bonds_results_company.rds"))
+} else {
+  log_warn("Bonds_results_portfolio.rds not found. Creating empty data frame.")
+  bonds_results_portfolio <- pacta.portfolio.utils::empty_portfolio_results()
+  bonds_results_company <- pacta.portfolio.utils::empty_company_results()
+}
 
 # data from PACTA inputs used to generate the results --------------------------
 log_debug("Loading benchmark results.")

--- a/R/prepare_pacta_dashboard_data.R
+++ b/R/prepare_pacta_dashboard_data.R
@@ -50,11 +50,19 @@ scen_geo_levels <- unlist(manifest$params$analysis$scenarioGeographiesList)
 # load results from input directory --------------------------------------------
 log_debug("Loading results from input directory.")
 
+log_trace("Loading audit_file.rds")
 audit_file <- readRDS(file.path(analysis_output_dir, "audit_file.rds"))
+
+log_trace("Loading emissions.rds")
 emissions <- readRDS(file.path(analysis_output_dir, "emissions.rds"))
+
+log_trace("Loading Equity_results_portfolio.rds")
 equity_results_portfolio <- readRDS(file.path(analysis_output_dir, "Equity_results_portfolio.rds"))
+log_trace("Loading Bonds_results_portfolio.rds")
 bonds_results_portfolio <- readRDS(file.path(analysis_output_dir, "Bonds_results_portfolio.rds"))
+log_trace("Loading Equity_results_company.rds")
 equity_results_company <- readRDS(file.path(analysis_output_dir, "Equity_results_company.rds"))
+log_trace("Loading Bonds_results_company.rds")
 bonds_results_company <- readRDS(file.path(analysis_output_dir, "Bonds_results_company.rds"))
 
 

--- a/tests/config/only-cb_2023Q4.json
+++ b/tests/config/only-cb_2023Q4.json
@@ -1,0 +1,15 @@
+{
+  "holdingsDate": "2023Q4",
+  "pactaDataURL": "https://pactadatadev.blob.core.windows.net/pacta-data-webapp/2023Q4/2023Q4_20240424T120055Z",
+  "benchmarksURL": "https://pactadatadev.blob.core.windows.net/benchmarks-webapp/2023Q4/2023Q4_20240529T002355Z",
+  "parameters": {
+    "portfolio": {
+      "holdingsDate": "2023-12-31",
+      "files": [
+        "bonds_portfolio.csv"
+      ],
+      "name": "Default Portfolio"
+    },
+    "inherit": "GENERAL_2023Q4"
+  }
+}

--- a/tests/config/only-eq_2023Q4.json
+++ b/tests/config/only-eq_2023Q4.json
@@ -1,0 +1,15 @@
+{
+  "holdingsDate": "2023Q4",
+  "pactaDataURL": "https://pactadatadev.blob.core.windows.net/pacta-data-webapp/2023Q4/2023Q4_20240424T120055Z",
+  "benchmarksURL": "https://pactadatadev.blob.core.windows.net/benchmarks-webapp/2023Q4/2023Q4_20240529T002355Z",
+  "parameters": {
+    "portfolio": {
+      "holdingsDate": "2023-12-31",
+      "files": [
+        "equity_portfolio.csv"
+      ],
+      "name": "Default Portfolio"
+    },
+    "inherit": "GENERAL_2023Q4"
+  }
+}

--- a/tests/portfolios/bonds_portfolio.csv
+++ b/tests/portfolios/bonds_portfolio.csv
@@ -1,0 +1,2 @@
+isin,market_value,currency
+US822582AD40,1000000,USD

--- a/tests/portfolios/equity_portfolio.csv
+++ b/tests/portfolios/equity_portfolio.csv
@@ -1,0 +1,2 @@
+isin,market_value,currency
+GB00BP6MXD84,1000000,USD


### PR DESCRIPTION
Currently, if either equity or bonds results are missing from the analysis (because the portfolio doesn't include those asset classes) then dashboarding process fails with an error:

> cannot open compressed file '/home/workflow-pacta-webapp/create-dashboard183733793/analysis-output/Bonds_results_portfolio.rds', probable reason 'No such file or directory'

This PR allows the process to continue even if one of those files is missing.

Note: tests for EQ- and CB-only portfolios added in https://github.com/RMI-PACTA/workflow.pacta.dashboard/pull/56/commits/3c443af3286cae621134529c140f9419a7780fbb